### PR TITLE
fix for github.com/netlify-templates/one-click-hugo-cms/issues/187

### DIFF
--- a/site/layouts/partials/footer.html
+++ b/site/layouts/partials/footer.html
@@ -50,4 +50,8 @@
 
 {{ partial "svg" . }}
 
-<script src="/app.js"></script>
+
+{{ $app := .Site.Data.webpack.app }}
+{{ with $app.js }}
+<script src="{{ relURL . }}"></script>
+{{ end }}

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -9,6 +9,7 @@ module.exports = {
   entry: {
     main: path.join(__dirname, "src", "index.js"),
     cms: path.join(__dirname, "src", "js", "cms.js"),
+    app: path.join(__dirname, "src", "js", "app.js"),
   },
 
   output: {


### PR DESCRIPTION
Does not look like app.js was included in the build.
This resolves this.

Please review, I'm no programmer so I've literally done enough to get that file into the build/remove the 404 error.