### PR TITLE
make footer blurb about subscription editable in the cms

### DIFF
--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -16,5 +16,7 @@ products:
 values:
     heading: Our values
     text: Coffee is an amazing part of human culture but it has a dark side too – one of colonialism and mindless abuse of natural resources and human lives. We want to turn this around and return the coffee trade to the drink’s exhilarating, empowering and unifying nature.
+footer_title: Newsletter subscribe
+footer_blurb: Get awesome news from us in your inbox every two weeks. Be the first to learn about new products.
 ---
 

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -16,7 +16,5 @@ products:
 values:
     heading: Our values
     text: Coffee is an amazing part of human culture but it has a dark side too – one of colonialism and mindless abuse of natural resources and human lives. We want to turn this around and return the coffee trade to the drink’s exhilarating, empowering and unifying nature.
-footer_title: Newsletter subscribe
-footer_blurb: Get awesome news from us in your inbox every two weeks. Be the first to learn about new products.
 ---
 

--- a/site/data/footer.json
+++ b/site/data/footer.json
@@ -1,0 +1,4 @@
+{
+    "title": "Newsletter subscribe",
+    "blurb": "Get awesome news from us in your inbox every two weeks. Be the first to learn about new products."
+}

--- a/site/layouts/partials/footer.html
+++ b/site/layouts/partials/footer.html
@@ -5,8 +5,10 @@
 		<div class="measure-narrow center mb4">
 
 			<img src="/img/logo.svg" alt="Kaldi logo" class="db w4 center mb4 br0">
-			<p class="f3 lh-title light-gray b tc mb2">Newsletter subscribe</p>
-			<p>Get awesome news from us in your inbox every two weeks. Be the first to learn about new products.</p>
+			{{ with .GetPage "/_index.md" }}
+				<p class="f3 lh-title light-gray b tc mb2">{{ .Params.footer_title }}</p>
+				<p>{{ .Params.footer_blurb }}</p>
+			{{ end }}
 
 			{{ partial "newsletter-form" . }}
 

--- a/site/layouts/partials/footer.html
+++ b/site/layouts/partials/footer.html
@@ -5,10 +5,8 @@
 		<div class="measure-narrow center mb4">
 
 			<img src="/img/logo.svg" alt="Kaldi logo" class="db w4 center mb4 br0">
-			{{ with .GetPage "/_index.md" }}
-				<p class="f3 lh-title light-gray b tc mb2">{{ .Params.footer_title }}</p>
-				<p>{{ .Params.footer_blurb }}</p>
-			{{ end }}
+			<p class="f3 lh-title light-gray b tc mb2">{{ .Site.Data.footer.title }}</p>
+			<p>{{ .Site.Data.footer.blurb }}</p>
 
 			{{ partial "newsletter-form" . }}
 

--- a/site/static/admin/config.yml
+++ b/site/static/admin/config.yml
@@ -20,7 +20,7 @@ collections: # A list of collections the CMS should be able to edit
     label: "Pages"
     files:
       - file: "site/content/_index.md"
-        label: "Home Page and Footer"
+        label: "Home Page"
         name: "home"
         fields:
           - {label: Title, name: title, widget: string}
@@ -38,9 +38,6 @@ collections: # A list of collections the CMS should be able to edit
           - {label: "Values", name: "values", widget: "object", fields: [
               {label: "Heading", name: "heading", widget: string},
               {label: "Text", name: "text", widget: "text"}]}
-          # fields for the footer that appears on all pages
-          - {label: "Footer Title", name: footer_title, widget: string}
-          - {label: "Footer Blurb", name: footer_blurb, widget: text}
       - file: "site/content/contact/_index.md"
         label: "Contact Page"
         name: "contact"
@@ -84,3 +81,9 @@ collections: # A list of collections the CMS should be able to edit
               - {label: Heading, name: heading, widget: string}
               - {label: Text, name: text, widget: text}
               - {label: Image, name: imageUrl, widget: image}
+      - file: "site/data/footer.json"
+        label: Footer
+        name: footer
+        fields:
+          - {label: Title, name: title, widget: string}
+          - {label: Blurb, name: blurb, widget: text}

--- a/site/static/admin/config.yml
+++ b/site/static/admin/config.yml
@@ -20,7 +20,7 @@ collections: # A list of collections the CMS should be able to edit
     label: "Pages"
     files:
       - file: "site/content/_index.md"
-        label: "Home Page"
+        label: "Home Page and Footer"
         name: "home"
         fields:
           - {label: Title, name: title, widget: string}
@@ -38,6 +38,9 @@ collections: # A list of collections the CMS should be able to edit
           - {label: "Values", name: "values", widget: "object", fields: [
               {label: "Heading", name: "heading", widget: string},
               {label: "Text", name: "text", widget: "text"}]}
+          # fields for the footer that appears on all pages
+          - {label: "Footer Title", name: footer_title, widget: string}
+          - {label: "Footer Blurb", name: footer_blurb, widget: text}
       - file: "site/content/contact/_index.md"
         label: "Contact Page"
         name: "contact"

--- a/src/js/cms-preview-templates/footer.js
+++ b/src/js/cms-preview-templates/footer.js
@@ -1,0 +1,14 @@
+import React from "react";
+import format from "date-fns/format";
+
+export default class FooterPreview extends React.Component {
+  render() {
+    const {entry, getAsset} = this.props;
+    return <div class="measure-narrow center mb4">
+
+			  <p class="f3 lh-title light-gray b tc mb2">{entry.getIn(["data", "title"])}</p>
+			  <p>{entry.getIn(["data", "blurb"])}</p>
+
+		 </div>
+  }
+}

--- a/src/js/cms.js
+++ b/src/js/cms.js
@@ -9,6 +9,7 @@ import PostPreview from "./cms-preview-templates/post";
 import ProductsPreview from "./cms-preview-templates/products";
 import ValuesPreview from "./cms-preview-templates/values";
 import ContactPreview from "./cms-preview-templates/contact";
+import FooterPreview from "./cms-preview-templates/footer";
 
 CMS.registerPreviewStyle(styles, { raw: true });
 CMS.registerPreviewTemplate("home", HomePreview);
@@ -16,4 +17,5 @@ CMS.registerPreviewTemplate("post", PostPreview);
 CMS.registerPreviewTemplate("products", ProductsPreview);
 CMS.registerPreviewTemplate("values", ValuesPreview);
 CMS.registerPreviewTemplate("contact", ContactPreview);
+CMS.registerPreviewTemplate("footer", FooterPreview);
 CMS.init();


### PR DESCRIPTION
**- Summary**

I was using this template and I needed parts of the footer to be editable in the CMS. I thought that might be something useful to contribute upstream, and maybe I can get some feedback on the design.

I added the footer fields to the home page and then used those variables in the footer partial, so that they are editable on the home page.

![screenshot of editing footer fields](https://github.com/decaporg/one-click-hugo-cms/assets/15057442/31fd554f-4a37-4080-a157-0203be7b9ea7)


**- Test plan**

[deploy](https://cms-footer-one-click-hugo-cms.netlify.app/)

**- Description for the changelog**

Make subscription text in footer editable in CMS

**- A picture of a cute animal (not mandatory but encouraged)**
![duck falling asleep](https://github.com/decaporg/one-click-hugo-cms/assets/15057442/f87c5585-a124-4437-af68-2b98e47e3ecf)
