### PR TITLE
products page: remove duplicated intro description

### DIFF
--- a/site/content/products/_index.md
+++ b/site/content/products/_index.md
@@ -2,13 +2,13 @@
 title: Our Coffee
 type: products
 image: /img/products-jumbotron.jpg
-heading: What we offer
-description: >-
-  Kaldi is the ultimate spot for coffee lovers who want to learn about their
-  java’s origin and support the farmers that grew it. We take coffee production,
-  roasting and brewing seriously and we’re glad to pass that knowledge to
-  anyone.
 intro:
+  heading: What we offer
+  description: >-
+    Kaldi is the ultimate spot for coffee lovers who want to learn about their
+    java’s origin and support the farmers that grew it. We take coffee production,
+    roasting and brewing seriously and we’re glad to pass that knowledge to
+    anyone.
   blurbs:
     - image: /img/illustrations-coffee.svg
       text: >
@@ -37,12 +37,6 @@ intro:
         space where you can hang out with fellow coffee lovers and learn about
         coffee making techniques. All of the artwork on display there is for
         sale. The full price you pay goes to the artist.
-  heading: What we offer
-  description: >
-    Kaldi is the ultimate spot for coffee lovers who want to learn about their
-    java’s origin and support the farmers that grew it. We take coffee
-    production, roasting and brewing seriously and we’re glad to pass that
-    knowledge to anyone. This is an edit via identity...
 main:
   heading: Great coffee with no compromises
   description: >

--- a/site/static/admin/config.yml
+++ b/site/static/admin/config.yml
@@ -61,8 +61,6 @@ collections: # A list of collections the CMS should be able to edit
         fields:
           - {label: Title, name: title, widget: string}
           - {label: Image, name: image, widget: image}
-          - {label: Heading, name: heading, widget: string}
-          - {label: Description, name: description, widget: string}
           - {label: Intro, name: intro, widget: object, fields: [{label: Heading, name: heading, widget: string}, {label: Description, name: description, widget: text}, {label: Blurbs, name: blurbs, widget: list, fields: [{label: Image, name: image, widget: image}, {label: Text, name: text, widget: text}]}]}
           - {label: Main, name: main, widget: object, fields: [{label: Heading, name: heading, widget: string}, {label: Description, name: description, widget: text}, {label: Image1, name: image1, widget: object, fields: [{label: Image, name: image, widget: image}, {label: Alt, name: alt, widget: string}]}, {label: Image2, name: image2, widget: object, fields: [{label: Image, name: image, widget: image}, {label: Alt, name: alt, widget: string}]}, {label: Image3, name: image3, widget: object, fields: [{label: Image, name: image, widget: image}, {label: Alt, name: alt, widget: string}]}]}
           - {label: Testimonials, name: testimonials, widget: list, fields: [{label: Quote, name: quote, widget: string}, {label: Author, name: author, widget: string}]}


### PR DESCRIPTION
**- Summary**

The products page only uses one copy of the intro description, so the other one is redundant.

**- Test plan**

The product page still looks the same in a [test deployment](https://tb-one-click-hugo-cms.netlify.app/products/).

**- Description for the changelog**

products page: remove duplicated intro description

**- A picture of a cute animal (not mandatory but encouraged)**
![dog-water-spray](https://github.com/decaporg/one-click-hugo-cms/assets/15057442/5425e52e-854e-4368-82ae-11ed856ec74f)

