### PR TITLE
social icons: add alt text to social icons

### DIFF
--- a/site/layouts/partials/footer.html
+++ b/site/layouts/partials/footer.html
@@ -36,10 +36,10 @@
 			<div>
 				<h3 class="f4 b lh-title mb2 primary">Social media</h3>
 				<ul class="mhn2">
-					{{ partial "social-icon" (dict "link" "#" "svg" "icons-facebook") }}
-					{{ partial "social-icon" (dict "link" "#" "svg" "icons-twitter") }}
-					{{ partial "social-icon" (dict "link" "#" "svg" "icons-instagram") }}
-					{{ partial "social-icon" (dict "link" "#" "svg" "icons-vimeo") }}
+					{{ partial "social-icon" (dict "link" "#" "svg" "icons-facebook" "alt" "Kaldi on Facebook") }}
+					{{ partial "social-icon" (dict "link" "#" "svg" "icons-twitter" "alt" "Kaldi on Twitter") }}
+					{{ partial "social-icon" (dict "link" "#" "svg" "icons-instagram" "alt" "Kaldi on Instagram") }}
+					{{ partial "social-icon" (dict "link" "#" "svg" "icons-vimeo" "alt" "Kaldi on Vimeo") }}
 				</ul>
 			</div>
 

--- a/site/layouts/partials/social-icon.html
+++ b/site/layouts/partials/social-icon.html
@@ -1,6 +1,8 @@
 <li class="dib ph2 raise">
   <a href="{{.link}}" class="link bg-white black db relative br-100 pa2">
-    <svg width="16px" height="16px" class="db">
+    <!-- see SVG tips for alt text https://www.w3.org/WAI/tutorials/images/tips/ -->
+    <svg width="16px" height="16px" class="db" aria-labelledby="alt-{{.svg}}">
+      <title id="alt-{{.svg}}">{{.alt}}</title>
       <use xlink:href="#{{.svg}}"></use>
     </svg>
   </a>


### PR DESCRIPTION
**- Summary**

add alt text on social media icons

References:
- [Images as link logo](https://www.w3.org/WAI/tutorials/images/functional/#example-1-image-used-alone-as-a-linked-logo)
- [Alt text on inline svg](https://www.w3.org/WAI/tutorials/images/tips/)

**- Test plan**

[deploy](https://tb-one-click-hugo-cms.netlify.app/)

**- Description for the changelog**

add alt text on social media icons

**- A picture of a cute animal (not mandatory but encouraged)**
![squirrel on a bird feeder](https://github.com/decaporg/one-click-hugo-cms/assets/15057442/3a4bce67-d47c-48dc-9a0d-616dd333d050)
