### PR TITLE
add cypress scripts for local testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ Clone this repository, and run `yarn` or `npm install` from the new folder to in
 
 Then start the development server with `yarn start` or `npm start`.
 
+## Testing
+
+With the development server running, run the tests locally
+with `yarn cypress:run` or `npm run cypress:run`.
+Or use `yarn cypress:open` or `npm run cypress:open` to run interactively.
+
+Cypress tests also run on deploy with the [Cypress Netlify integration](https://www.netlify.com/integrations/cypress/).
+
 ## Layouts
 
 The template is based on small, content-agnostic partials that can be mixed and matched. The pre-built pages showcase just a few of the possible combinations. Refer to the `site/layouts/partials` folder for all available partials.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "build:preview": "npm run build:webpack && npm run build:hugo:preview",
     "build:hugo": "hugo -d ../dist -s site -v",
     "build:hugo:preview": "npm run build:hugo -- -D -F",
-    "build:webpack": "cross-env NODE_ENV=production webpack --config webpack.prod.js"
+    "build:webpack": "cross-env NODE_ENV=production webpack --config webpack.prod.js",
+    "cypress:open": "cypress open --e2e",
+    "cypress:run": "cypress run --e2e"
   },
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
**- Summary**

The tests run on netlify already, but it wasn't obvious how to run them locally, so I added scripts in `package.json` to make it easy.

**- Test plan**

With the development server running (`yarn start` or `npm start`), run
- `yarn cypress:run`
- `npm run cypress:run`
- `yarn cypress:open`
- `npm run cypress:open`

**- Description for the changelog**

add cypress scripts for local testing