### PR TITLE
remove image preview hack to fix image preview

### DIFF
--- a/src/js/cms-preview-templates/home.js
+++ b/src/js/cms-preview-templates/home.js
@@ -2,15 +2,10 @@ import React from "react";
 
 import Jumbotron from "./components/jumbotron";
 
-export default class PostPreview extends React.Component {
+export default class HomePreview extends React.Component {
   render() {
     const {entry, getAsset} = this.props;
-    let image = getAsset(entry.getIn(["data", "image"]));
-
-    // Bit of a nasty hack to make relative paths work as expected as a background image here
-    if (image && !image.fileObj) {
-      image = window.parent.location.protocol + "//" + window.parent.location.host + image;
-    }
+    const image = getAsset(entry.getIn(["data", "image"]));
 
     return <div>
       <Jumbotron image={image} title={entry.getIn(["data", "title"])} subtitle={entry.getIn(["data", "subtitle"])}/>

--- a/src/js/cms-preview-templates/products.js
+++ b/src/js/cms-preview-templates/products.js
@@ -2,15 +2,10 @@ import React from "react";
 
 import Jumbotron from "./components/jumbotron";
 
-export default class PostPreview extends React.Component {
+export default class ProductsPreview extends React.Component {
   render() {
     const {entry, getAsset} = this.props;
-    let image = getAsset(entry.getIn(["data", "image"]));
-
-    // Bit of a nasty hack to make relative paths work as expected as a background image here
-    if (image && !image.fileObj) {
-      image = window.parent.location.protocol + "//" + window.parent.location.host + image;
-    }
+    const image = getAsset(entry.getIn(["data", "image"]));
 
     return <div>
       <Jumbotron image={image} title={entry.getIn(["data", "title"])} />

--- a/src/js/cms-preview-templates/values.js
+++ b/src/js/cms-preview-templates/values.js
@@ -21,13 +21,7 @@ export default class ValuesPreview extends React.Component {
   render() {
     const {entry, getAsset} = this.props;
 
-    let image = getAsset(entry.getIn(["data", "image"]));
-
-    // Bit of a nasty hack to make relative paths work as expected as a background image here
-    if (image && !image.fileObj) {
-      image = window.parent.location.protocol + "//" + window.parent.location.host + image;
-    }
-
+    const image = getAsset(entry.getIn(["data", "image"]));
     const entryValues = entry.getIn(["data", "values"]);
     const values = entryValues ? entryValues.toJS() : [];
 


### PR DESCRIPTION
**- Summary**

I don't understand the original hack well enough to explain why it's not necessary. All I know is that by removing it, the image shows up for me.

**- Test plan**
In the CMS, edit a page and check that the image exists in the preview.

**- Description for the changelog**

remove image preview hack to fix image preview

Fixes #320