### PR TITLE
fix DecapCMS editing of hugo.toml

### DIFF
--- a/site/static/admin/config.yml
+++ b/site/static/admin/config.yml
@@ -88,7 +88,7 @@ collections: # A list of collections the CMS should be able to edit
         fields:
           - {label: Title, name: title, widget: string}
           - {label: Blurb, name: blurb, widget: text}
-      - file: "site/config.toml"
+      - file: "site/hugo.toml"
         label: Hugo Config
         name: config
         editor:


### PR DESCRIPTION
**- Summary**

The DecapCMS `config.yml` references the Hugo configuration as `config.toml`, but it's actually `hugo.toml`.  This was broken in #775.

**- Test plan**

In the DecapCMS interface: Collections > Site Settings > Hugo Config.  Check that current settings appear in the interface and that editing works.

**- Description for the changelog**

fix DecapCMS editing of `hugo.toml`