### PR TITLE
remove hugo build lock file and add it to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ site/data/webpack.json
 /npm-debug.log
 yarn-error.log
 .netlify/
+.hugo_build.lock
 
 cypress/videos
 cypress/screenshots


### PR DESCRIPTION
**- Summary**

A Hugo build lock file was accidentally added in a earlier pull request.
https://github.com/decaporg/one-click-hugo-cms/pull/674/files#r1162884652

**- Description for the changelog**

remove hugo build lock file and add it to gitignore