### PR TITLE
Fix identity widget script URL

### DIFF
--- a/src/cms.html
+++ b/src/cms.html
@@ -6,7 +6,7 @@
 
   <title>Content Manager</title>
 
-  <script src="https://identity-js.netlify.com/v1/netlify-identity-widget.js"></script>
+  <script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
 </head>
 <body>
     <script src="<%= htmlWebpackPlugin.publicPath %>/<%= htmlWebpackPlugin.files.js[1] %>"></script>


### PR DESCRIPTION
**- Summary**

- `https://identity-js.netlify.com/v1/netlify-identity-widget.js` results in a 404 error.
- Adjusting the URL to `https://identity.netlify.com/v1/netlify-identity-widget.js` fixes the problem

**- Test plan**

Load `/admin` and see no errors to load NetlifyIdentityWidget JS


**- Description for the changelog**

Fix identity widget config
